### PR TITLE
Add knife docker image

### DIFF
--- a/knife/Dockerfile
+++ b/knife/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:slim
+
+RUN mkdir -p /knife
+WORKDIR /knife
+VOLUME /knife
+RUN set -ex                                              \
+    && buildDeps='libgmp3-dev gcc make'                  \
+    && apt update                                        \
+    && apt upgrade -y                                    \
+    && apt install -y --no-install-recommends $buildDeps \
+    && rm -rf /var/lib/apt/lists/*                       \
+    && gem install chef --version '~>12'                 \
+    && apt purge -y --auto-remove $buildDeps
+RUN gem install bundler:1.17.1
+ENTRYPOINT ["knife"]
+CMD ["--help"]

--- a/knife/README.md
+++ b/knife/README.md
@@ -1,0 +1,2 @@
+# Usage
+This image is used by Jenkins jobs that run `chef.knife` docker commands like Dispatch. 


### PR DESCRIPTION
Public image was updated at some point breaking our builds for dispatch.
This locks down bundler version in the image for compatibility.